### PR TITLE
Adding missing location column

### DIFF
--- a/twint/storage/db.py
+++ b/twint/storage/db.py
@@ -73,6 +73,7 @@ def init(db):
                     name text,
                     username text not null,
                     bio text,
+                    location text,
                     url text,
                     join_date text not null,
                     join_time text not null,


### PR DESCRIPTION
With the following switches, Twint will be doing the scraping, but unable to save the results in the database due to the missing Location column in the Followers table:
python3 Twint.py -u target_username --followers --user-full --database twitter.db 