### PR TITLE
Bug fix: not all followers found 

### DIFF
--- a/twint/output.py
+++ b/twint/output.py
@@ -24,7 +24,10 @@ def is_tweet(tw):
 def _output(obj, output, config):
     if config.Output != None:
         if config.Store_csv:
-            write.Csv(obj, config)
+            try :
+                write.Csv(obj, config)
+            except Exception as e:
+                print("Error: " + str(e))
         elif config.Store_json:
             write.Json(obj, config)
         else:
@@ -43,8 +46,9 @@ def _output(obj, output, config):
         else:
             try:
                 print(output)
-            except UnicodeEncodeError:
                 pass
+            except UnicodeEncodeError:
+                print("unicode error")
 
 async def Tweets(tw, location, config, conn):
     copyright = tw.find("div", "StreamItemContent--withheld")

--- a/twint/user.py
+++ b/twint/user.py
@@ -4,9 +4,11 @@ class user:
 def inf(ur, _type):
     try:
         group = ur.find("div", "user-actions btn-group not-following ")
-    except:
-        group = ur.find("div", "user-actions btn-group not-following protected")
-    
+        if group == None :
+            group = ur.find("div", "user-actions btn-group not-following protected")
+    except Exception as e:
+        print("Error: " + str(e))
+
     if _type == "id":
         ret = group["data-user-id"]
     elif _type == "name":
@@ -42,15 +44,41 @@ def join(ur):
     jd = ur.find("span", "ProfileHeaderCard-joinDateText js-tooltip u-dir")["title"]
     return jd.split(" - ")
 
+def convertToInt(x):
+    multDict = {
+        "k" : 1000,
+        "m" : 1000000,
+        "b" : 1000000000,
+    }
+    try :
+        y = int(x)
+        return y
+    except :
+        pass
+    
+    try :
+        y = float(str(x)[:-1])
+        y = y * multDict[str(x)[-1:].lower()]
+        return int(y)
+    except :
+        pass
+
+    return 0
+
 def stat(ur, _type):
     _class = f"ProfileNav-item ProfileNav-item--{_type}"
     stat = ur.find("li", _class)
-    return stat.find("span", "ProfileNav-value")["data-count"]
+    try :
+        r = stat.find("span", "ProfileNav-value")["data-count"]
+    except AttributeError:
+        r = "0"
+    return r
 
 def media(ur):
     try:
         media_count = ur.find("a", "PhotoRail-headingWithCount js-nav").text
         media_count = media_count.replace("\n", "")[32:].split(" ")[0]
+        media_count = convertToInt(media_count)
     except:
         media_count = "0"
 


### PR DESCRIPTION
when user_full used. 1. When media number is over 1000 twitter writes it as 3.2k = 3200 which is now accounted for. 2. When se
arching for information, protected accounts were never found. This was because the code expected .find to fail when no r
esult when in reality it returns None. Corrected this to check for None and try the other option.


I can see you may be making some changes to the find followers code but this was my solution.