### PR TITLE
Fix bug when outputting an object (output.py)

### DIFF
--- a/twint/output.py
+++ b/twint/output.py
@@ -43,12 +43,14 @@ def _output(obj, output, config, **extra):
             obj = obj.lower()
         elif str(type(obj)) == "<class 'twint.user.user'>":
             pass
-        else:
+        elif str(type(obj)) == "<class 'twint.tweet.tweet'>":
             obj.username = obj.username.lower()
             for i in range(len(obj.mentions)):
                 obj.mentions[i] = obj.mentions[i].lower()
             for i in range(len(obj.hashtags)):
                 obj.hashtags[i] = obj.hashtags[i].lower()
+        else:
+            obj = ""
     if config.Output != None:
         if config.Store_csv:
             try :


### PR DESCRIPTION
Sometime, the `obj` argument of `_output` will be different from a tweet, a user or a string (for example a beautiful soup tag).
This check that `obj` is indeed an instance of Tweet before accessing its members.

How to reproduce:
Run the following script:
```
import twint

c = twint.Config()
c.Search = "#BalanceTonPorc"
c.Until = "2017-10-24"
c.Store_json=True
c.Output="btp.json"

twint.run.Search(c)
```
The script should fail after downloading approximately 600 tweets.

I'm not sure on what to what to put for `obj` on the default, so for now it's `""`.