### PR TITLE
Changed mentions datatype to list if empty (not string)

### DIFF
--- a/twint/tweet.py
+++ b/twint/tweet.py
@@ -18,7 +18,7 @@ def getMentions(tw):
     try:
         mentions = tw["data-mentions"].split(" ")
     except:
-        mentions = ""
+        mentions = []
 
     return mentions
 


### PR DESCRIPTION
Just a small suggestion:

In my opinion the return value of `getMentions` should consistently be a list. 
Currently it's an empty string if the tweet has no mentions and a list otherwise.