### PR TITLE
store tweets in a specified list if it exists in config object

### DIFF
--- a/twint/config.py
+++ b/twint/config.py
@@ -37,6 +37,7 @@ class Config:
     User_full = False
     Profile_full = False
     Store_object = False
+    Store_object_tweets_list = None
     Pandas_type = None
     Pandas = False
     Index_tweets = "twinttweets"

--- a/twint/output.py
+++ b/twint/output.py
@@ -125,7 +125,10 @@ async def checkData(tweet, config, conn):
 
             if config.Store_object:
                 logme.debug(__name__+':checkData:Store_object')
-                tweets_object.append(tweet)
+                if hasattr(config.Store_object_tweets_list, 'append'):
+                    config.Store_object_tweets_list.append(tweet)
+                else:
+                    tweets_object.append(tweet)
 
             if config.Elasticsearch:
                 logme.debug(__name__+':checkData:Elasticsearch')


### PR DESCRIPTION
Fixes #461:

`twint.output.checkData()` now checks if there's a `config.Store_object_tweets_list` with an `append` method, aka a list. If so, it stores the tweets there. Otherwise, it stores the tweets in the usual `twint.ouput.tweets_object`.

I would have included documentation, but it's only in the wiki which I don't have access to. But, here's a proposed markdown snippet you could add near `Save data (tweets, users, ...) in lists (RAM)`:

#### Specify which list to store tweets:

```python
import twint

tweets = []

c = twint.Config()

c.Username = 'noneprivacy'
c.Limit = 10
c.Store_object = True
c.Store_object_tweets_list = tweets

twint.run.Search(c)
tweets = twint.output.tweets_object
```