### PR TITLE
Declare support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ language: python
 python:
   - "3.6"
   - "3.7"
-  - "3.8-dev"
+  - "3.8"
   - "nightly"
 matrix:
   allow_failures:
-    - python: "3.8-dev"
     - python: "nightly"
 install:
 - pip install -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,7 @@ setup(
 		'Programming Language :: Python :: 3',
 		'Programming Language :: Python :: 3.6',
 		'Programming Language :: Python :: 3.7',
+		'Programming Language :: Python :: 3.8',
+		'Programming Language :: Python :: Implementation :: CPython',
 		],
 )


### PR DESCRIPTION
Hello @pielco11,

Python 3.8 is released, so I believe that it would be nice to declare support for it.

Python 3.8.0 release announcement:
https://discuss.python.org/t/python-3-8-0-is-now-available/2478

Best regards!