### PR TITLE
fix pip command via github

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ pip3 install twint
 or
 
 ```bash
+pip3 install --upgrade -e git+https://github.com/twintproject/twint.git@origin/master#egg=twint
+```
+
+If you want to install twint in your home directory:
+
+```bash
 pip3 install --user --upgrade -e git+https://github.com/twintproject/twint.git@origin/master#egg=twint
 ```
 


### PR DESCRIPTION
`pip3 install --user` places binary as command in `~/.local/bin`.
`~/.local/bin` is not common, I think that many users have not added  `~/.local/bin` to `PATH`.

```
$ pip3 install --user --upgrade --e git+https://github.com/twintproject/twint.git@origin/master#egg=twint
$ ls /Users/tkmru/.local/bin
twint
```

If command example is removed user option, binary is placed in the same path as `pip instal twint`.
I recommend not adding user options.

``` 
$ pip3 install --upgrade -e git+https://github.com/twintproject/twint.git@origin/master#egg=twint
$ which twint
/Users/tkmru/.pyenv/shims/twint
```