### PR TITLE
t.retweet_date should represents when retweeted

### DIFF
--- a/twint/tweet.py
+++ b/twint/tweet.py
@@ -98,7 +98,7 @@ def Tweet(tw, config):
     t.user_rt_id, t.user_rt = getRetweet(tw)
     t.retweet = True if t.user_rt else False
     t.retweet_id = tw['data-retweet-id'] if t.user_rt else ''
-    t.retweet_date = datetime.fromtimestamp(((t.retweet_id >> 22) + 1288834974657)/1000.0).strftime("%Y-%m-%d %H:%M:%S") if t.user_rt else ''
+    t.retweet_date = datetime.fromtimestamp(((int(t.retweet_id) >> 22) + 1288834974657)/1000.0).strftime("%Y-%m-%d %H:%M:%S") if t.user_rt else ''
     t.quote_url = getQuoteURL(tw)
     t.near = config.Near if config.Near else ""
     t.geo = config.Geo if config.Geo else ""

--- a/twint/tweet.py
+++ b/twint/tweet.py
@@ -98,7 +98,7 @@ def Tweet(tw, config):
     t.user_rt_id, t.user_rt = getRetweet(tw)
     t.retweet = True if t.user_rt else False
     t.retweet_id = tw['data-retweet-id'] if t.user_rt else ''
-    t.retweet_date = datetime.fromtimestamp(((t.id >> 22) + 1288834974657)/1000.0).strftime("%Y-%m-%d %H:%M:%S") if t.user_rt else ''
+    t.retweet_date = datetime.fromtimestamp(((t.retweet_id >> 22) + 1288834974657)/1000.0).strftime("%Y-%m-%d %H:%M:%S") if t.user_rt else ''
     t.quote_url = getQuoteURL(tw)
     t.near = config.Near if config.Near else ""
     t.geo = config.Geo if config.Geo else ""


### PR DESCRIPTION
## Expected:
`tweet.retweet_date` returns datetime of when retweeted the results by every user.

## Actual:
`tweet.retweet_date` returns datetime of when tweeted original tweet.

# Why shoud fix this
We can get original tweeted datetime by `tweet.datetime` attribute.
Why are you return same datetime in `tweet.datetime` and `tweet.retweet_date` ?

## Before
[![Screenshot from Gyazo](https://gyazo.com/f3f026f6c7cb06be08f682c9366ff65c/raw)](https://gyazo.com/f3f026f6c7cb06be08f682c9366ff65c)

## After
[![Screenshot from Gyazo](https://gyazo.com/2c8c5daa10bd25fa840b628bce0caabe/raw)](https://gyazo.com/2c8c5daa10bd25fa840b628bce0caabe)
