### PR TITLE
get.RequestUrl inside try block in run.Feed

### DIFF
--- a/twint/config.py
+++ b/twint/config.py
@@ -51,7 +51,7 @@ class Config:
     Pandas_clean = True
     Lowercase = True
     Pandas_au = True
-    Proxy_host = None
+    Proxy_host = ""
     Proxy_port = 0
     Proxy_type = None
     Tor_control_port = 9051

--- a/twint/get.py
+++ b/twint/get.py
@@ -48,7 +48,7 @@ user_agent_list = [
 def get_connector(config):
     logme.debug(__name__+':get_connector')
     _connector = None
-    if config.Proxy_host is not None:
+    if config.Proxy_host:
         if config.Proxy_host.lower() == "tor":
             _connector = SocksConnector(
                 socks_ver=SocksVer.SOCKS5,

--- a/twint/run.py
+++ b/twint/run.py
@@ -46,12 +46,13 @@ class Twint:
         logme.debug(__name__+':Twint:Feed')
         consecutive_errors_count = 0
         while True:
-            response = await get.RequestUrl(self.config, self.init, headers=[("User-Agent", self.user_agent)])
-            if self.config.Debug:
-                print(response, file=open("twint-last-request.log", "w", encoding="utf-8"))
-                
-            self.feed = []
             try:
+                response = await get.RequestUrl(self.config, self.init, headers=[("User-Agent", self.user_agent)])
+                if self.config.Debug:
+                    print(response, file=open("twint-last-request.log", "w", encoding="utf-8"))
+                
+                self.feed = []
+                
                 if self.config.Favorites:
                     self.feed, self.init = feed.Mobile(response)
                     if not self.count%40:
@@ -69,7 +70,7 @@ class Twint:
                     self.feed, self.init = feed.Json(response)
                 break
             except TimeoutError as e:
-                if self.config.Proxy_host.lower() == "tor":
+                if self.config.Proxy_host != None and self.config.Proxy_host.lower() == "tor":
                     print("[?] Timed out, changing Tor identity...")
                     if self.config.Tor_control_password is None:
                         logme.critical(__name__+':Twint:Feed:tor-password')


### PR DESCRIPTION
get.RequestUrl is now inside the try block in run.Feed, since it used to raise exceptions in long queries.

Also, as it is going to be catch in the Timeout except block, i noticed there is a call to Proxy_host.tolower(), but Proxy_host is None by default. That is why I added a check.

