### PR TITLE
Allow calling library to detect possible rate limiting and provide some custom pause behavior

### DIFF
--- a/twint/config.py
+++ b/twint/config.py
@@ -73,4 +73,8 @@ class Config:
     Filter_retweets = False
     Translate = False
     TranslateSrc = "en"
-    TranslateDest = "en"    
+    TranslateDest = "en" 
+    Rate_limit_info = None
+    Rate_limit_pause = True
+    Rate_limit_pause_min = 60
+    Rate_limit_pause_max = 120


### PR DESCRIPTION
Based on a few of the issues, i have made this pull request for comment from you  @pielco11 to see what you think, not sure how you would like to handle this really but I found this implementation useful.

I think it is clear there is some rate limiting going on, and I think we need to handle it so that the calling library can detect it and decide what to do (with Config.Resume, proxy setting changes etc.)

This change adds the following config items:

`Rate_limit_info` = None - if specified, some data will be dumped into this file when rate limiting might be happening
`Rate_limit_pause` = True - if true, a small pause randomly between `Rate_limit_pause_min` and `Rate_limit_pause_max` will happen when rate limiting might be happening
`Rate_limit_pause_min` = 60
`Rate_limit_pause_max` = 120

I also removed one of the console errors that prints asking users to raise an issue with the library, it’s not a library issue it needs to be handled by the calling program to get around the rate limiting so not really worth pointing people here to open issues I think?

As I said, this is for comment, if you want it I am happy to update the docs etc. to make it complete before merging or take any other advice - I also have not looked at how this works on the CLI yet.
