### PR TITLE
[FEAT] Pass follower / follower and user lists.

### DIFF
--- a/twint/config.py
+++ b/twint/config.py
@@ -37,6 +37,8 @@ class Config:
     Profile_full = False
     Store_object = False
     Store_object_tweets_list = None
+    Store_object_users_list = None
+    Store_object_follow_list = None
     Pandas_type = None
     Pandas = False
     Index_tweets = "twinttweets"
@@ -73,4 +75,4 @@ class Config:
     Filter_retweets = False
     Translate = False
     TranslateSrc = "en"
-    TranslateDest = "en"    
+    TranslateDest = "en"

--- a/twint/output.py
+++ b/twint/output.py
@@ -175,8 +175,19 @@ async def Users(u, config, conn):
 
     if config.Store_object:
         logme.debug(__name__+':User:Store_object')
-        users_list.append(user) # twint.user.user
-    
+
+        if config.Followers or config.Following:
+            if hasattr(config.Store_object_follow_list, 'append'):
+                config.Store_object_follow_list.append(user)
+            else:
+                users_list.append(user) # twint.user.user
+
+        # also populate using the previous method to avoid breaking changes
+        if hasattr(config.Store_object_users_list, 'append'):
+            config.Store_object_users_list.append(user)
+        else:
+            users_list.append(user) # twint.user.user
+
     if config.Pandas:
         logme.debug(__name__+':User:Pandas+user')
         panda.update(obj, config)
@@ -198,7 +209,10 @@ async def Username(username, config, conn):
         elasticsearch.Follow(username, config)
 
     if config.Store_object:
-        follows_list.append(username)
+        if hasattr(config.Store_object_follow_list, 'append'):
+            config.Store_object_follow_list.append(username)
+        else:
+            follows_list.append(username) # twint.user.user
 
     if config.Pandas:
         logme.debug(__name__+':Username:object+pandas')


### PR DESCRIPTION
Adds the ability to provide external references for populating:

1. Followers list via `twint.run.Followers`
1. Following list via `twint.run.Following`
1. User lookup list via `twint.run.Lookup`.

Adds two new configuration options:

1. `Store_object_users_list`: Reference to user  supplied list when calling `twint.run.Lookup`, can also be used when calling `twint.run.Followers`, or `twint.run.Following` with `Config.User_full = True`
1. `Store_object_follow_list`: Reference to user supplied list when calling `twint.run.Followers`  or `twint.run.Following`. 

Example usage:

```python3
import twint

c = twint.Config()
c.Username = "twitter"
c.Store_object_follow_list = []

twint.run.Followers(c)

print(f"Retrieved {len(c.Store_object_follow_list)} followers of {c.Username}")
```

Example usage:

```python3
import twint

c = twint.Config()
c.Username = "twitter"
c.Store_object_users_list = []
c.User_full = True

twint.run.Followers(c)

print(f"Retrieved {len(c.Store_object_users_list)} followers of {c.Username}")
```

In the case of the `twint.run.Follow` and `twint.run.Following`, the supplied `Store_object_follow_list ` list will be populated with either usernames as strings **or** instances of `User`, based on the `Config.User_full`. 

Note that this is different than the current implementation that requires users to access the right `twint.output` variable (e.g. accessing `twint.output.users_list` when `Config.User_full = True` or `twint.output.follows_list` when `Config.User_full = False` 

