### PR TITLE
exponential backoff; configurable min- and max-delays

### DIFF
--- a/twint/cli.py
+++ b/twint/cli.py
@@ -124,6 +124,9 @@ def initialize(args):
     c.Filter_retweets = args.filter_retweets
     c.Translate = args.translate
     c.TranslateDest = args.translate_dest
+    c.Backoff_base = args.backoff_base
+    c.Min_delay = args.min_delay
+    c.Max_delay = args.max_delay
     return c
 
 def options():
@@ -220,6 +223,10 @@ def options():
     ap.add_argument("--source", help="Filter the tweets for specific source client.")
     ap.add_argument("--members-list", help="Filter the tweets sent by users in a given list.")
     ap.add_argument("-fr", "--filter-retweets", help="Exclude retweets from the results.", action="store_true")
+    ap.add_argument("--backoff-base", help="Specify a base for the exponential backoff in case of errors.",
+                    type=float, default=1.8)
+    ap.add_argument("--min-delay", help="Specify a minimum delay between certain requests.", type=int, default=5)
+    ap.add_argument("--max-delay", help="Specify a maximum delay between certain requests.", type=int, default=5)
     args = ap.parse_args()
 
     return args

--- a/twint/config.py
+++ b/twint/config.py
@@ -74,3 +74,6 @@ class Config:
     Translate = False
     TranslateSrc = "en"
     TranslateDest = "en"    
+    Min_delay = 5
+    Max_delay = 5
+    Backoff_base = 1.8

--- a/twint/run.py
+++ b/twint/run.py
@@ -1,6 +1,7 @@
 import sys, os, time
 from asyncio import get_event_loop, TimeoutError, ensure_future, new_event_loop, set_event_loop
 from datetime import datetime
+import random
 
 from . import datelock, feed, get, output, verbose, storage
 from .storage import db
@@ -55,11 +56,15 @@ class Twint:
                 if self.config.Favorites:
                     self.feed, self.init = feed.Mobile(response)
                     if not self.count%40:
-                        time.sleep(5)
+                        delay = random.randint(self.config.Min_delay, self.config.Max_delay)
+                        sys.stderr.write('sleeping for {} secs\n'.format(delay))
+                        time.sleep(delay)
                 elif self.config.Followers or self.config.Following:
                     self.feed, self.init = feed.Follow(response)
                     if not self.count%40:
-                        time.sleep(5)
+                        delay = random.randint(self.config.Min_delay, self.config.Max_delay)
+                        sys.stderr.write('sleeping for {} secs\n'.format(delay))
+                        time.sleep(delay)
                 elif self.config.Profile:
                     if self.config.Profile_full:
                         self.feed, self.init = feed.Mobile(response)
@@ -91,11 +96,14 @@ class Twint:
                 # Sometimes Twitter says there is no data. But it's a lie.
                 consecutive_errors_count += 1
                 if consecutive_errors_count < self.config.Retries_count:
-                    self.user_agent = await get.RandomUserAgent()
+                    delay = round(self.config.Backoff_base ** consecutive_errors_count, 1)
+                    sys.stderr.write('sleeping for {} secs\n'.format(delay))
+                    time.sleep(delay)
+                    self.user_agent = await get.RandomUserAgent(True)
                     continue
                 logme.critical(__name__+':Twint:Feed:Tweets_known_error:' + str(e))
-                print(str(e) + " [x] run.Feed")
-                print("[!] if get this error but you know for sure that more tweets exist, please open an issue and we will investigate it!")
+                sys.stderr.write(str(e) + " [x] run.Feed")
+                sys.stderr.write("[!] if get this error but you know for sure that more tweets exist, please open an issue and we will investigate it!")
                 break
         if self.config.Resume:
             print(self.init, file=open(self.config.Resume, "a", encoding="utf-8"))


### PR DESCRIPTION
I have made the following additions:

- exponential backoff on error. The backoff base can be specified with `--backoff-base`. A typical value would be between 1 and 2. Default is 1.8. This gives delays of 1.8, 3.2, 5.8, 10.4, 18.9, 34.4 seconds on subsequent errors. 2 would delay 2, 4, 8, 16, 32 and so on. 1 would always delay one second.

- configurable sleep times on Favorites, Followers and Following. This was always 5 seconds. It will be a random number between configurable min and max values. Both are default 5 (so the same behavior). Configure them with --min-delay and --max-delay.

- fix a bug. The fixed user agent would become random after the first failure.

- print some error msgs to stderr to make this easier to debug and parse the output.