### PR TITLE
Fix username error

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ import twint
 
 # Configure
 c = twint.Config()
-c.Username = "now"
-c.Search = "fruit"
+c.Username = "realDonaldTrump"
+c.Search = "great"
 
 # Run
 twint.run.Search(c)

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ import twint
 
 # Configure
 c = twint.Config()
-c.Username = "realDonaldTrump"
-c.Search = "great"
+c.Username = "now"
+c.Search = "fruit"
 
 # Run
 twint.run.Search(c)

--- a/twint/run.py
+++ b/twint/run.py
@@ -167,6 +167,8 @@ class Twint:
             logme.debug(__name__+':Twint:main:username')
             url = f"https://twitter.com/{self.config.Username}?lang=en"
             self.config.User_id = await get.User(url, self.config, self.conn, True)
+            if self.config.User_id is None:
+                raise ValueError("Cannot find twitter account with name = " + self.config.Username)
 
         if self.config.TwitterSearch and self.config.Since and self.config.Until:
             logme.debug(__name__+':Twint:main:search+since+until')


### PR DESCRIPTION
Before if you put wrong username you would see the following error:
`CRITICAL:root:twint.get:User:'NoneType' object is not subscriptable
`
Error like that doesn't tell you much:

I propose this change to make error more interpretable.

now with the wrong username the error would be:

```
Traceback (most recent call last):
  File "/Users/user/projects/twint/check_twint.py", line 9, in <module>
    twint.run.Search(c)
  File "/Users/user/projects/twint/twint/run.py", line 329, in Search
    run(config, callback)
  File "/Users/user/projects/twint/twint/run.py", line 228, in run
    get_event_loop().run_until_complete(Twint(config).main(callback))
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/base_events.py", line 579, in run_until_complete
    return future.result()
  File "/Users/user/projects/twint/twint/run.py", line 154, in main
    await task
  File "/Users/user/projects/twint/twint/run.py", line 171, in run
    raise ValueError("Cannot find twitter account with name = " + self.config.Username)
ValueError: Cannot find twitter account with name = realDonaldTrumpsdfasdfasdf
```