### PR TITLE
:Retweet are not stored

### DIFF
--- a/twint/storage/db.py
+++ b/twint/storage/db.py
@@ -96,7 +96,7 @@ def init(db):
                     username text not null,
                     tweet_id integer not null,
                     retweet_id integer not null,
-                    retweet_date integer not null,
+                    retweet_date integer,
                     CONSTRAINT retweets_pk PRIMARY KEY(user_id, tweet_id),
                     CONSTRAINT user_id_fk FOREIGN KEY(user_id) REFERENCES users(id),
                     CONSTRAINT tweet_id_fk FOREIGN KEY(tweet_id) REFERENCES tweets(id)

--- a/twint/storage/elasticsearch.py
+++ b/twint/storage/elasticsearch.py
@@ -97,7 +97,7 @@ def createIndex(config, instance, **scope):
                                 "username": {"type": "keyword"}
                             }
                         },
-                        "retweet_date": {"type": "date", "format": "yyyy-MM-dd HH:mm:ss"},
+                        "retweet_date": {"type": "date", "format": "yyyy-MM-dd HH:mm:ss", "ignore_malformed": True},
                         "urls": {"type": "keyword"},
                         "translate": {"type": "text"},
                         "trans_src": {"type": "keyword"},


### PR DESCRIPTION
Related with issues #740.

Retweets are not stored because the value of retweet_date field are empty. This field are empty because twitter not show this information now.