### PR TITLE
Making timezone format more portable 

### DIFF
--- a/twint/tweet.py
+++ b/twint/tweet.py
@@ -90,7 +90,7 @@ def Tweet(tw, config):
     t.username = tw["data-screen-name"]
     t.name = tw["data-name"]
     t.place = tw.find("a","js-geo-pivot-link").text.strip() if tw.find("a","js-geo-pivot-link") else ""
-    t.timezone = strftime("%Z", localtime())
+    t.timezone = strftime("%z", localtime())
     for img in tw.findAll("img", "Emoji Emoji--forText"):
         img.replaceWith(img["alt"])
     t.mentions = getMentions(tw)


### PR DESCRIPTION
right now timezones are written in the text format:
we have stuff like "FLE Standard Time" or "'Vladivostok Standard Time'"  in the t.timezone variable.
I propose to replace it with a more portable format which is UTF offset (it looks like +0000, -0400):
https://docs.python.org/3/library/datetime.html

That would be easier to use because one won't need a dictionary of timezones names. 

