### PR TITLE
send header so can retrieve user by username

### DIFF
--- a/twint/get.py
+++ b/twint/get.py
@@ -179,7 +179,7 @@ async def User(url, config, conn, user_id = False):
     logme.debug(__name__+':User')
     _connector = get_connector(config)
     try:
-        response = await Request(url, connector=_connector)
+        response = await Request(url, connector=_connector, headers={"X-Requested-With": "XMLHttpRequest"})
         soup = BeautifulSoup(response, "html.parser")
         if user_id:
             return int(inf(soup, "id"))


### PR DESCRIPTION
Closes #772 

Today, doing a Lookup by Username is also requiring this header. Without this header, Twitter is sending a form asking if we want to use the Legacy site since it 'detects' that JavaScript is not enabled, hence the call fails.