### PR TITLE
Fix users list storage in RAM

### DIFF
--- a/twint/output.py
+++ b/twint/output.py
@@ -194,6 +194,8 @@ async def Users(u, config, conn):
 
         if hasattr(config.Store_object_follow_list, 'append'):
             config.Store_object_follow_list.append(user)
+        elif hasattr(config.Store_object_users_list, 'append'):
+            config.Store_object_users_list.append(user)
         else:
             users_list.append(user) # twint.user.user
 


### PR DESCRIPTION
Modified `output.py` to add support for `Store_object_users_list`. #772 