### PR TITLE
Stop `check(args)` complaints and trust the user Custom Query

### DIFF
--- a/twint/cli.py
+++ b/twint/cli.py
@@ -36,7 +36,9 @@ def check(args):
             error("Contradicting Args",
                   "--all and -u cannot be used together")
     elif args.search is None:
-        if (args.geo or args.near) is None and not (args.all or args.userid):
+        if args.custom_query is not None:
+            pass
+        elif (args.geo or args.near) is None and not (args.all or args.userid):
             error("Error", "Please use at least -u, -s, -g or --near.")
     elif args.all and args.userid:
         error("Contradicting Args",


### PR DESCRIPTION
Just a little hack to allow passing `-cq` as the only parameter when using from CLI.