### PR TITLE
fetching favorites and parsing in a new way

### DIFF
--- a/twint/feed.py
+++ b/twint/feed.py
@@ -28,6 +28,18 @@ def Mobile(response):
 
     return tweets, max_id
 
+def MobileFav(response):
+
+    soup = BeautifulSoup(response, "html.parser")
+    tweets = soup.find_all("table", "tweet")
+    max_id = soup.find_all("div", "w-button-more")
+    try:
+        max_id = findall(r'max_id=(.*?)">', str(max_id))[0]
+    except Exception as e:
+        print(str(e) + " [x] feed.MobileFav")
+
+    return tweets, max_id
+
 def profile(response):
     logme.debug(__name__+':profile')
     json_response = loads(response)


### PR DESCRIPTION
**Problems fixed**

1) Twitter returns login screen/ enable js screen for some of our user agents on twint. 
For passing this, if parsing was not successful -if self.feed or self.init is empty- I try with a different user agent selected randomly until the proccess reaches the success. (Max try count is 5)

2) Since twitter returns a different page for favorited tweets, it should have been parsed differently. Favorited tweets does not include [data-item-id] field and cannot be parsed using Tweet object. I've parsed the page in favorite function which placed in run.py . Since tweets was not including timestamps, I have parsed date from the unofficial date format like ["1m", "2h", "Jun 21, 2019", "Mar 12", "28 Jun 19"]

Output includes **tweet text, tweet id, conversation id and date**