### PR TITLE
Update get.py

### DIFF
--- a/twint/get.py
+++ b/twint/get.py
@@ -9,7 +9,7 @@ import asyncio
 import concurrent.futures
 import random
 from json import loads
-from aiohttp_socks import SocksConnector, SocksVer
+from aiohttp_socks import ProxyConnector, ProxyType
 
 from . import url
 from .output import Tweets, Users
@@ -50,16 +50,16 @@ def get_connector(config):
     _connector = None
     if config.Proxy_host:
         if config.Proxy_host.lower() == "tor":
-            _connector = SocksConnector(
-                socks_ver=SocksVer.SOCKS5,
+            _connector = ProxyConnector(
+                socks_ver=ProxyType.SOCKS5,
                 host='127.0.0.1',
                 port=9050,
                 rdns=True)
         elif config.Proxy_port and config.Proxy_type:
             if config.Proxy_type.lower() == "socks5":
-                _type = SocksVer.SOCKS5
+                _type = ProxyType.SOCKS5
             elif config.Proxy_type.lower() == "socks4":
-                _type = SocksVer.SOCKS4
+                _type = ProxyType.SOCKS4
             elif config.Proxy_type.lower() == "http":
                 global httpproxy
                 httpproxy = "http://" + config.Proxy_host + ":" + str(config.Proxy_port)
@@ -68,7 +68,7 @@ def get_connector(config):
                 logme.critical("get_connector:proxy-type-error")
                 print("Error: Proxy types allowed are: http, socks5 and socks4. No https.")
                 sys.exit(1)
-            _connector = SocksConnector(
+            _connector = ProxyConnector(
                 socks_ver=_type,
                 host=config.Proxy_host,
                 port=config.Proxy_port,


### PR DESCRIPTION
With recent update of aiohttp_socks on July 16, 2020 - due to deprecation SocksConnector was renamed to ProxyConnector and SocksVer was renamed to ProxyType.