### PR TITLE
Tabbed CSV output (option)

### DIFF
--- a/twint/cli.py
+++ b/twint/cli.py
@@ -87,6 +87,7 @@ def initialize(args):
     c.Phone = args.phone
     c.Verified = args.verified
     c.Store_csv = args.csv
+    c.Tabs = args.tabs
     c.Store_json = args.json
     c.Show_hashtags = args.hashtags
     c.Show_cashtags = args.cashtags
@@ -159,6 +160,7 @@ def options():
     ap.add_argument("--verified", help="Display Tweets only from verified users (Use with -s).",
                     action="store_true")
     ap.add_argument("--csv", help="Write as .csv file.", action="store_true")
+    ap.add_argument("--tabs", help="Separate CSV fields with tab characters, not commas.", action="store_true")
     ap.add_argument("--json", help="Write as .json file", action="store_true")
     ap.add_argument("--hashtags", help="Output hashtags in seperate column.", action="store_true")
     ap.add_argument("--cashtags", help="Output cashtags in seperate column.", action="store_true")

--- a/twint/storage/write.py
+++ b/twint/storage/write.py
@@ -53,14 +53,15 @@ def Csv(obj, config):
     fieldnames, row = struct(obj, config.Custom[_obj_type], _obj_type)
     
     base = addExt(config.Output, _obj_type, "csv")
+    dialect = 'excel-tab' if config.Tabs else 'excel'
     
     if not (os.path.exists(base)):
         with open(base, "w", newline='', encoding="utf-8") as csv_file:
-            writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+            writer = csv.DictWriter(csv_file, fieldnames=fieldnames, dialect=dialect)
             writer.writeheader()
 
     with open(base, "a", newline='', encoding="utf-8") as csv_file:
-        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames, dialect=dialect)
         writer.writerow(row)
 
 def Json(obj, config):


### PR DESCRIPTION
Twitter does not allow the tab character in tweets, so it is an ideal separator.  Separating with commas (i.e. without this option) results in ambiguity.