### PR TITLE
fixes #976: saving tweets to csv

### DIFF
--- a/twint/storage/write.py
+++ b/twint/storage/write.py
@@ -53,7 +53,7 @@ def Csv(obj, config):
     fieldnames, row = struct(obj, config.Custom[_obj_type], _obj_type)
     
     base = addExt(config.Output, _obj_type, "csv")
-    dialect = 'excel-tab' if config.Tabs else 'excel'
+    dialect = 'excel-tab' if 'Tabs' in config.__dict__ else 'excel'
     
     if not (os.path.exists(base)):
         with open(base, "w", newline='', encoding="utf-8") as csv_file:


### PR DESCRIPTION
This patch fixes the issue caused by #967, which broke the functionality of saving the retrieved data into a csv file.

#967 added the functionality of saving the tweets to csv with `tabs` instead of `,` but didn't handle the case when `--tabs` is not provided in the command line. which would later throw an `AttributeError` in **write.py**.

This patch fixes the following issues:
#990
#983
#976 

Although I have merged this branch into my master, which already have a PR on the project, I'll still keep this PR because this problem has a higher priority, and is fixed simply by changing a line.
Thus this can be merged much quickly into the twintproject:master, whereas my master has a lot of fixes and a lot of code has changed in it so it might take some time for that to get checked and eventually get merged.

In the meantime merging this into the project would provide a quick fix to people who are not being able to save the results to csv.