### PR TITLE
fix(csv): fixes csv output method

### DIFF
--- a/twint/storage/write.py
+++ b/twint/storage/write.py
@@ -53,7 +53,7 @@ def Csv(obj, config):
     fieldnames, row = struct(obj, config.Custom[_obj_type], _obj_type)
     
     base = addExt(config.Output, _obj_type, "csv")
-    dialect = 'excel-tab' if 'Tabs' in config.__dict__ else 'excel'
+    dialect = 'excel-tab' if 'Tabs' in config.__dict__ and config.Tabs else 'excel'
     
     if not (os.path.exists(base)):
         with open(base, "w", newline='', encoding="utf-8") as csv_file:


### PR DESCRIPTION
output was being saved to csv using the `tabs` dialect even when --tabs flag
wasn't specified. this patch fixes that issue.

Initially #967 was merged which caused the #976 issue.
To fix the issue #998 was merged but it only partially solved the issue.
Default method for saving CSV was changed to `tabs` instead of `comma / ,` and there was no way to change that.

This PR solves the issue stated above.