### PR TITLE
Fix user full config

### DIFF
--- a/twint/config.py
+++ b/twint/config.py
@@ -39,7 +39,7 @@ class Config:
     Favorites: bool = False
     TwitterSearch: bool = False
     User_full: bool = False
-    # Profile_full: bool = False
+    Profile_full: bool = False
     Store_object: bool = False
     Store_object_tweets_list: list = None
     Store_object_users_list: list = None

--- a/twint/get.py
+++ b/twint/get.py
@@ -261,7 +261,7 @@ async def Multi(feed, config, conn):
 
                 if config.User_full:
                     logme.debug(__name__ + ':Multi:user-full-Run')
-                    futures.append(loop.run_in_executor(executor, await User(url,
+                    futures.append(loop.run_in_executor(executor, await User(username,
                                                                              config, conn)))
                 else:
                     logme.debug(__name__ + ':Multi:notUser-full-Run')

--- a/twint/user.py
+++ b/twint/user.py
@@ -18,7 +18,7 @@ User_formats = {
 # ur object must be a json from the endpoint https://api.twitter.com/graphql
 def User(ur):
     logme.debug(__name__ + ':User')
-    if 'data' not in ur and 'user' not in ur['data']:
+    if 'data' not in ur or 'user' not in ur['data']:
         msg = 'malformed json! cannot be parsed to get user data'
         logme.fatal(msg)
         raise KeyError(msg)
@@ -28,7 +28,9 @@ def User(ur):
     _usr.username = ur['data']['user']['legacy']['screen_name']
     _usr.bio = ur['data']['user']['legacy']['description']
     _usr.location = ur['data']['user']['legacy']['location']
-    _usr.url = ur['data']['user']['legacy']['url']
+    _usr.url = ""
+    if 'url' in ur['data']['user']['legacy']:
+        _usr.url = ur['data']['user']['legacy']['url']
     # parsing date to user-friendly format
     _dt = ur['data']['user']['legacy']['created_at']
     _dt = datetime.datetime.strptime(_dt, '%a %b %d %H:%M:%S %z %Y')
@@ -46,7 +48,9 @@ def User(ur):
     _usr.is_private = ur['data']['user']['legacy']['protected']
     _usr.is_verified = ur['data']['user']['legacy']['verified']
     _usr.avatar = ur['data']['user']['legacy']['profile_image_url_https']
-    _usr.background_image = ur['data']['user']['legacy']['profile_banner_url']
+    _usr.background_image = ""
+    if 'profile_banner_url' in ur['data']['user']['legacy']:
+        _usr.background_image = ur['data']['user']['legacy']['profile_banner_url']
     # TODO : future implementation
     # legacy_extended_profile is also available in some cases which can be used to get DOB of user
     return _usr


### PR DESCRIPTION
### Changes:
- Setting `Config.User_full` wasn't outputting anything because:
  - the argument passed into the `User` function was `url` instead of `username`
  - `Profile_full` field in config was commented out. This caused unhandled exceptions when trying to access it the `get.Multi` function.
- Avoid `NoneTypes` when parsing json for user to avoid downstream errors.