### PR TITLE
Added a configurable Tor proxy IP

### DIFF
--- a/twint/config.py
+++ b/twint/config.py
@@ -61,6 +61,8 @@ class Config:
     Proxy_host: str = ""
     Proxy_port: int = 0
     Proxy_type: object = None
+    Tor_ip: str = "127.0.0.1"
+    Tor_port: int = 9050
     Tor_control_port: int = 9051
     Tor_control_password: str = None
     Retweets: bool = False

--- a/twint/get.py
+++ b/twint/get.py
@@ -71,8 +71,8 @@ def get_connector(config):
     if config.Proxy_host:
         if config.Proxy_host.lower() == "tor":
             _connector = ProxyConnector(
-                host='127.0.0.1',
-                port=9050,
+                host=config.Tor_ip,
+                port=config.Tor_port,
                 rdns=True)
         elif config.Proxy_port and config.Proxy_type:
             if config.Proxy_type.lower() == "socks5":
@@ -143,7 +143,8 @@ async def RequestUrl(config, init):
 def ForceNewTorIdentity(config):
     logme.debug(__name__ + ':ForceNewTorIdentity')
     try:
-        tor_c = socket.create_connection(('127.0.0.1', config.Tor_control_port))
+        tor_c = socket.create_connection(
+            (config.Tor_ip, config.Tor_control_port))
         tor_c.send('AUTHENTICATE "{}"\r\nSIGNAL NEWNYM\r\n'.format(config.Tor_control_password).encode())
         response = tor_c.recv(1024)
         if response != b'250 OK\r\n250 OK\r\n':


### PR DESCRIPTION
I'm working on a project and I want to dockerize my code.
But the tor IP is hardcoded, so I changed it to a variable (the default behaviour is the same).
With this fix you can use twint with an external torproxy.

# My use case
python:
```python3
twint_config = twint.Config()
twint_config.Proxy_host = "tor"
twint_config.Tor_ip = environ['TOR_IP'] if 'TOR_IP' in environ else "127.0.0.1"
twint_config.Tor_control_password = ""
```

docker-compose.yml
```yaml
version: "3.8"

services:
  app:
    build: .
    environment:
      - TOR_IP=torproxy
  torproxy:
    image: dperson/torproxy:latest
    ports:
      - "9050" # Tor proxy
      - "9051" # Tor control port
```